### PR TITLE
Fixed withYears setting not being used

### DIFF
--- a/dist/native/index.d.mts
+++ b/dist/native/index.d.mts
@@ -28,6 +28,12 @@ interface Settings {
      */
     stopOnZero?: boolean;
     /**
+     * Should the timer display years?
+     *
+     * @type {boolean}
+     */
+    withYears?: boolean;
+    /**
      * The function will be called before instance initialization.
      *
      * @type {Function}
@@ -51,6 +57,7 @@ declare class Timezz {
     date: DateType;
     pause: boolean;
     stopOnZero: boolean;
+    withYears: boolean;
     isDestroyed: boolean;
     beforeCreate?: () => void;
     beforeUpdate?: () => void;
@@ -70,4 +77,5 @@ declare namespace timezz {
     var prototype: Timezz;
 }
 
-export { type Settings, Timezz, type UpdateEvent, timezz };
+export { Timezz, timezz };
+export type { Settings, UpdateEvent };

--- a/dist/native/index.d.ts
+++ b/dist/native/index.d.ts
@@ -28,6 +28,12 @@ interface Settings {
      */
     stopOnZero?: boolean;
     /**
+     * Should the timer display years?
+     *
+     * @type {boolean}
+     */
+    withYears?: boolean;
+    /**
      * The function will be called before instance initialization.
      *
      * @type {Function}
@@ -51,6 +57,7 @@ declare class Timezz {
     date: DateType;
     pause: boolean;
     stopOnZero: boolean;
+    withYears: boolean;
     isDestroyed: boolean;
     beforeCreate?: () => void;
     beforeUpdate?: () => void;
@@ -70,4 +77,5 @@ declare namespace timezz {
     var prototype: Timezz;
 }
 
-export { type Settings, Timezz, type UpdateEvent, timezz };
+export { Timezz, timezz };
+export type { Settings, UpdateEvent };

--- a/dist/native/index.mjs
+++ b/dist/native/index.mjs
@@ -44,6 +44,7 @@ class Timezz {
     __publicField(this, "date");
     __publicField(this, "pause", false);
     __publicField(this, "stopOnZero", true);
+    __publicField(this, "withYears", false);
     __publicField(this, "isDestroyed", false);
     __publicField(this, "beforeCreate");
     __publicField(this, "beforeUpdate");
@@ -72,6 +73,9 @@ class Timezz {
       if (typeof settings.stopOnZero !== "boolean") {
         warn("stopOnZero", ["boolean"]);
       }
+      if (typeof settings.withYears !== "boolean") {
+        warn("withYears", ["boolean"]);
+      }
       if (typeof settings.beforeCreate !== "function") {
         warn("beforeCreate", ["function"]);
       }
@@ -87,6 +91,7 @@ class Timezz {
     this.date = parseDate(userSettings.date);
     this.pause = userSettings.pause || false;
     this.stopOnZero = typeof userSettings.stopOnZero === "boolean" ? userSettings.stopOnZero : true;
+    this.withYears = typeof userSettings.withYears === "boolean" ? userSettings.withYears : false;
     this.beforeCreate = userSettings.beforeCreate;
     this.beforeUpdate = userSettings.beforeUpdate;
     this.update = userSettings.update;
@@ -135,8 +140,8 @@ class Timezz {
     const seconds = fixNumber(distance % ONE_MINUTE / ONE_SECOND);
     const minutes = fixNumber(distance % ONE_HOUR / ONE_MINUTE);
     const hours = fixNumber(distance % ONE_DAY / ONE_HOUR);
-    const days = fixNumber(distance % ONE_YEAR / ONE_DAY);
-    const years = fixNumber(distance / ONE_YEAR);
+    const days = this.withYears ? fixNumber(distance % ONE_YEAR / ONE_DAY) : fixNumber(distance / ONE_DAY);
+    const years = this.withYears ? fixNumber(distance / ONE_YEAR) : 0;
     if (this.HTMLParts.seconds) {
       count.seconds = seconds;
     }

--- a/dist/react/index.d.mts
+++ b/dist/react/index.d.mts
@@ -1,10 +1,16 @@
-import { FC, HTMLAttributes } from 'react';
-import { Settings } from '../native/index.mjs';
+import type { FC, HTMLAttributes } from 'react';
+import type { Settings } from '../native/index.mjs';
+
+
+
+
+
 
 interface TimezzProps extends HTMLAttributes<HTMLDivElement> {
     date: Settings['date'];
     pause: Settings['pause'];
     stopOnZero: Settings['stopOnZero'];
+    withYears: Settings['withYears'];
     onUpdate: Settings['update'];
 }
 declare const Timezz: FC<TimezzProps>;

--- a/dist/react/index.d.ts
+++ b/dist/react/index.d.ts
@@ -1,10 +1,16 @@
-import { FC, HTMLAttributes } from 'react';
-import { Settings } from '../native/index.js';
+import type { FC, HTMLAttributes } from 'react';
+import type { Settings } from '../native/index.js';
+
+
+
+
+
 
 interface TimezzProps extends HTMLAttributes<HTMLDivElement> {
     date: Settings['date'];
     pause: Settings['pause'];
     stopOnZero: Settings['stopOnZero'];
+    withYears: Settings['withYears'];
     onUpdate: Settings['update'];
 }
 declare const Timezz: FC<TimezzProps>;

--- a/dist/react/index.mjs
+++ b/dist/react/index.mjs
@@ -5,6 +5,7 @@ const Timezz = ({
   date,
   pause,
   stopOnZero,
+  withYears,
   onUpdate,
   children,
   ...props
@@ -16,6 +17,7 @@ const Timezz = ({
       date,
       pause,
       stopOnZero,
+      withYears,
       update: onUpdate
     });
     return () => {

--- a/dist/vue/index.d.mts
+++ b/dist/vue/index.d.mts
@@ -13,6 +13,10 @@ declare const Timezz: vue.DefineComponent<vue.ExtractPropTypes<{
         type: BooleanConstructor;
         default: boolean;
     };
+    withYears: {
+        type: BooleanConstructor;
+        default: boolean;
+    };
 }>, () => vue.VNode<vue.RendererNode, vue.RendererElement, {
     [key: string]: any;
 }>, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, "update"[], "update", vue.PublicProps, Readonly<vue.ExtractPropTypes<{
@@ -28,11 +32,16 @@ declare const Timezz: vue.DefineComponent<vue.ExtractPropTypes<{
         type: BooleanConstructor;
         default: boolean;
     };
+    withYears: {
+        type: BooleanConstructor;
+        default: boolean;
+    };
 }>> & Readonly<{
     onUpdate?: ((...args: any[]) => any) | undefined;
 }>, {
     pause: boolean;
     stopOnZero: boolean;
+    withYears: boolean;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 export { Timezz };

--- a/dist/vue/index.d.ts
+++ b/dist/vue/index.d.ts
@@ -13,6 +13,10 @@ declare const Timezz: vue.DefineComponent<vue.ExtractPropTypes<{
         type: BooleanConstructor;
         default: boolean;
     };
+    withYears: {
+        type: BooleanConstructor;
+        default: boolean;
+    };
 }>, () => vue.VNode<vue.RendererNode, vue.RendererElement, {
     [key: string]: any;
 }>, {}, {}, {}, vue.ComponentOptionsMixin, vue.ComponentOptionsMixin, "update"[], "update", vue.PublicProps, Readonly<vue.ExtractPropTypes<{
@@ -28,11 +32,16 @@ declare const Timezz: vue.DefineComponent<vue.ExtractPropTypes<{
         type: BooleanConstructor;
         default: boolean;
     };
+    withYears: {
+        type: BooleanConstructor;
+        default: boolean;
+    };
 }>> & Readonly<{
     onUpdate?: ((...args: any[]) => any) | undefined;
 }>, {
     pause: boolean;
     stopOnZero: boolean;
+    withYears: boolean;
 }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
 
 export { Timezz };

--- a/dist/vue/index.mjs
+++ b/dist/vue/index.mjs
@@ -15,6 +15,10 @@ const Timezz = defineComponent({
     stopOnZero: {
       type: Boolean,
       default: false
+    },
+    withYears: {
+      type: Boolean,
+      default: false
     }
   },
   emits: ["update"],
@@ -27,6 +31,7 @@ const Timezz = defineComponent({
           date: props.date,
           pause: props.pause,
           stopOnZero: props.stopOnZero,
+          withYears: props.withYears,
           update: (event) => {
             emit("update", event);
           }

--- a/src/native/index.test.ts
+++ b/src/native/index.test.ts
@@ -94,4 +94,18 @@ describe('options test', () => {
 
     expect(timerElement!.querySelector('[data-seconds]')!.innerHTML).toBe('00')
   })
+
+  it('show years', () => {
+    document.body.innerHTML = `<div>
+      <div class="j-timer">
+        <span data-years></span>
+      </div>
+    </div>`
+
+    const timerElement = document.querySelector('.j-timer')
+
+    timezz(timerElement!, { date: new Date(Date.now() + (86400 * 1000 * 365)), withYears: true, pause: true })
+
+    expect(timerElement!.querySelector('[data-years]')!.innerHTML).toBe('01')
+  })
 })

--- a/src/native/index.ts
+++ b/src/native/index.ts
@@ -44,6 +44,13 @@ export interface Settings {
   stopOnZero?: boolean
 
   /**
+   * Should the timer display years?
+   *
+   * @type {boolean}
+   */
+  withYears?: boolean
+
+  /**
    * The function will be called before instance initialization.
    *
    * @type {Function}
@@ -123,6 +130,8 @@ export class Timezz {
 
   stopOnZero = true
 
+  withYears = false
+
   isDestroyed = false
 
   beforeCreate?: () => void
@@ -149,6 +158,7 @@ export class Timezz {
     this.date = parseDate(userSettings.date)
     this.pause = userSettings.pause || false
     this.stopOnZero = typeof userSettings.stopOnZero === 'boolean' ? userSettings.stopOnZero : true
+    this.withYears = typeof userSettings.withYears === 'boolean' ? userSettings.withYears : false
     this.beforeCreate = userSettings.beforeCreate
     this.beforeUpdate = userSettings.beforeUpdate
     this.update = userSettings.update
@@ -179,6 +189,10 @@ export class Timezz {
 
     if (typeof settings.stopOnZero !== 'boolean') {
       warn('stopOnZero', ['boolean'])
+    }
+
+    if (typeof settings.withYears !== 'boolean') {
+      warn('withYears', ['boolean'])
     }
 
     if (typeof settings.beforeCreate !== 'function') {
@@ -246,8 +260,8 @@ export class Timezz {
     const seconds = fixNumber((distance % ONE_MINUTE) / ONE_SECOND)
     const minutes = fixNumber((distance % ONE_HOUR) / ONE_MINUTE)
     const hours = fixNumber((distance % ONE_DAY) / ONE_HOUR)
-    const days = fixNumber((distance % ONE_YEAR) / ONE_DAY)
-    const years = fixNumber(distance / ONE_YEAR)
+    const days = this.withYears ? fixNumber((distance % ONE_YEAR) / ONE_DAY) : fixNumber(distance / ONE_DAY)
+    const years = this.withYears ? fixNumber(distance / ONE_YEAR) : 0
 
     if (this.HTMLParts.seconds) {
       count.seconds = seconds

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -5,6 +5,7 @@ interface TimezzProps extends HTMLAttributes<HTMLDivElement> {
   date: Settings['date']
   pause: Settings['pause']
   stopOnZero: Settings['stopOnZero']
+  withYears: Settings['withYears']
   onUpdate: Settings['update']
 }
 
@@ -12,6 +13,7 @@ export const Timezz: FC<TimezzProps> = ({
   date,
   pause,
   stopOnZero,
+  withYears,
   onUpdate,
   children,
   ...props
@@ -24,6 +26,7 @@ export const Timezz: FC<TimezzProps> = ({
       date,
       pause,
       stopOnZero,
+      withYears,
       update: onUpdate,
     })
 

--- a/src/vue/index.ts
+++ b/src/vue/index.ts
@@ -16,6 +16,10 @@ export const Timezz = defineComponent({
       type: Boolean,
       default: false,
     },
+    withYears: {
+      type: Boolean,
+      default: false,
+    },
   },
   emits: ['update'],
   setup(props, { slots, emit }) {
@@ -28,6 +32,7 @@ export const Timezz = defineComponent({
           date: props.date,
           pause: props.pause,
           stopOnZero: props.stopOnZero,
+          withYears: props.withYears,
           update: (event) => {
             emit('update', event)
           },


### PR DESCRIPTION
## Fix: `withYears` setting now works  

### Description  
This PR fixes an issue where the `withYears` setting was not being used. Now, it correctly applies the setting.  

### Changes Made  
- Fixed how `withYears` is handled.  
- Added/updated tests to confirm it works.  
